### PR TITLE
Fix: Fixing 'quoi' multiline issue

### DIFF
--- a/modules/quoi_feur.js
+++ b/modules/quoi_feur.js
@@ -20,7 +20,7 @@ function init(client) {
 		if (message.author.bot || !config.quoi_feur) return;
 
 		// quoi en fin de phrase suivi par aucuns ou plusieurs caractères spéciaux dans n'importe quel ordre
-		const regex = new RegExp('quoi[ .!?"\':;^+=()*-,]*$', 'gim');
+		const regex = new RegExp('quoi[ .!?"\':;^+=()*-,]*$', 'gi');
 
 		if(regex.test(message.content)){
 			quoiFeurise(message);


### PR DESCRIPTION
When one line was triggering quoi, the quoi-feur joke trigered event if there was some text after..